### PR TITLE
Updated Knex to 0.12 for solve the build problem with uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "trailjs"
   ],
   "dependencies": {
-    "knex": "0.11.6",
+    "knex": "0.12.3",
     "lodash": "^4.0.0",
     "trailpack": "^1.0.0-alpha-7",
     "trailpack-datastore": "^1.0.0",


### PR DESCRIPTION
Updated Knex to 0.12 for solve the problem with node-uuid in Node4 ( https://travis-ci.org/trailsjs/trailpack-knex/jobs/166369356 )
